### PR TITLE
Prepare query before executing.

### DIFF
--- a/tools/tool_id_by_slug/index.php
+++ b/tools/tool_id_by_slug/index.php
@@ -5,8 +5,11 @@
 		function tool_id_by_slug( $slug ) {
 			
 			global $wpdb;
+
+			$sql = "SELECT ID FROM $wpdb->posts WHERE post_name = %s";
+			$query = $wpdb->prepare( $sql, $slug );
 			
-			return $wpdb->get_var( "SELECT ID FROM $wpdb->posts WHERE post_name = '" . $slug . "'" );
+			return $wpdb->get_var( $query );
 		}
 
 	// }


### PR DESCRIPTION
This is particularly important because `tool_get_an_id()` calls this function with parts of the URL in it, making this vulnerable to SQL injection.

This commit fixes that.
